### PR TITLE
bitly.com regression

### DIFF
--- a/easylist/easylist_thirdparty.txt
+++ b/easylist/easylist_thirdparty.txt
@@ -538,7 +538,6 @@
 ||d1aezk8tun0dhm.cloudfront.net^
 ||d1aqvw7cn4ydzo.cloudfront.net^
 ||d1ayv3a7nyno3a.cloudfront.net^
-||d1ayxb9ooonjts.cloudfront.net^
 ||d1az618or4kzj8.cloudfront.net^
 ||d1aznprfp4xena.cloudfront.net^
 ||d1azpphj80lavy.cloudfront.net^


### PR DESCRIPTION
This reverts part of f316bc037d570532987ce6964b579b52fcaf9861 from #16310 which included `d1ayxb9ooonjts.cloudfront.net` a false positive.

This causes a regression loading <bitly.com> and this domain is not used for Ads. (disclosure: I work @bitly) 

![Screenshot 2023-06-16 at 4 04 59 PM](https://github.com/jehiah/easylist/assets/45028/ce018ef4-3faf-4068-a3c8-52894d31ab5c)
